### PR TITLE
make the ImageMagick modifications synchronous

### DIFF
--- a/api/routes/users.js
+++ b/api/routes/users.js
@@ -218,8 +218,11 @@ router.post('/picture', async function (req, res) {
         });
     }
     try {
-        await writeFileSync(filePath, profilePicture.data, fileOptions);
-        await gm(filePath)
+        // write new profile picture to disk
+        writeFileSync(filePath, profilePicture.data, fileOptions);
+        // update db to point to new profile picture
+        await usersData.updateProfilePic(req.googleInfo.email, newFileName);
+        gm(filePath)
             .resize(240, 240)
             .autoOrient()
             .font(font, 32)
@@ -231,13 +234,13 @@ router.post('/picture', async function (req, res) {
                         err
                     );
                 }
+                // the profile picture is still saved, just not formatted by ImageMagick
+                res.sendStatus(200);
             });
-        await usersData.updateProfilePic(req.googleInfo.email, newFileName);
     } catch (e) {
         console.log('Error in /users/picture', e);
         return res.sendStatus(500);
     }
-    res.sendStatus(200);
 });
 
 module.exports = router;


### PR DESCRIPTION
Ensures the ImageMagick modifications take place before the route sends a response. The gm npm package uses callbacks so the response is set then. If ImageMagick fails, the route will still send a success response, since the file has successfully been saved to disk and updated in the DB just without the modifications.